### PR TITLE
Add backend testing setup

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,19 @@
+name: Python package
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Thermal-Sales
 Thermal Sales é um sistema inteligente de análise de comportamento em lojas físicas, que utiliza mapas de calor (heatmaps) para identificar zonas quentes e frias de movimentação e vendas.
+
+## Development
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run tests:
+
+```bash
+pytest
+```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello, World"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra -q
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pytest
+httpx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello, World"}


### PR DESCRIPTION
## Summary
- add FastAPI app and dummy endpoint
- configure pytest
- add sample test
- set up GitHub Actions workflow for running tests
- document how to run tests
- add `.gitignore`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854483d3df88333ae02177991d0c69d