### PR TITLE
Add backend pytest setup and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,23 @@
+name: Backend Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: |
+          cd backend
+          pytest -q

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -ra
+python_files = test_*.py

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 psycopg2-binary
+httpx

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_health():
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- configure pytest for the backend
- add a sample FastAPI endpoint test
- install httpx for the tests
- run tests on every push or PR with GitHub Actions

## Testing
- `pytest backend -q`

------
https://chatgpt.com/codex/tasks/task_e_68544a53ea3c8333bf9ff059916aee70